### PR TITLE
fix: remove invalid rss standard

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -11,7 +11,7 @@
 {{- $pages = $pages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>


### PR DESCRIPTION
https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fcity.shaform.com%2Fzh%2Findex.xml

in w3c rss validator, it shows

```
line 2, column 0: Use of unknown namespace: http://webfeeds.org/rss/1.0 [[help](https://validator.w3.org/feed/docs/warning/UnknownNamespace.html)]

<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:webfeeds=" ...
```

not all rss reader support the webfeeds tag, could remove the `xmlns:webfeeds="http://webfeeds.org/rss/1.0"` to increase compatibility.